### PR TITLE
Add package for docker image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,20 @@
         '';
       };
 
+      packages.docker = pkgs.dockerTools.buildLayeredImage {
+        name = "game-night";
+        tag = "0.1.0";
+        contents = [
+          pkgs.bash pkgs.coreutils
+        ];
+
+        config = {
+          Env = [ "VUE_BUNDLE=${packages.game-night-frontend}" ];
+          Cmd = [ "${packages.game-night-backend}/bin/game-night" ];
+          WorkingDir = "/app";
+        };
+      };
+
       defaultPackage = packages.game-night-backend;
 
       devShell = pkgs.mkShell {


### PR DESCRIPTION
- Build a layered image that contains the frontend and backend
  - Set the frontend folder as an environment variable
  - Set the backend binary as the default command to run

### Testing Steps

1. `nix build .#docker && docker load < result`
2. `docker run -it -p 2727:2727 game-night:0.1.0`
3. Visit `localhost:2727` in a browser and observe the JSON output for the demo endpoint

### Notes

- The backend does not currently log anything, so nothing is output when running
- Does not yet handle `CTRL-C` correctly, so you have to `docker stop` a container based on this image